### PR TITLE
Admin can add a new video sans uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,6 @@ end
 group :production do
   gem "sentry-raven", :git => "https://github.com/getsentry/raven-ruby.git"
   gem 'rails_12factor'
+  gem 'carrierwave'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,6 +56,11 @@ GEM
     capybara-email (2.4.0)
       capybara (~> 2.4)
       mail
+    carrierwave (0.10.0)
+      activemodel (>= 3.2.0)
+      activesupport (>= 3.2.0)
+      json (>= 1.7)
+      mime-types (>= 1.16)
     celluloid (0.16.0)
       timers (~> 4.0.0)
     coderay (1.1.0)
@@ -223,6 +228,7 @@ DEPENDENCIES
   bootstrap_form
   capybara (~> 2.4.4)
   capybara-email
+  carrierwave
   coffee-rails
   database_cleaner (= 1.2.0)
   fabrication (~> 2.12.2)

--- a/app/controllers/admin/videos_controller.rb
+++ b/app/controllers/admin/videos_controller.rb
@@ -2,4 +2,21 @@ class Admin::VideosController < AdminController
   def new
     @video = Video.new
   end
+
+  def create
+    @video = Video.new(video_params)
+    if @video.save
+      flash[:success] = "You successfully added #{@video.title}"
+      redirect_to new_admin_video_path
+    else
+      flash[:danger] = "Unable to add video. Please check for errors"
+      render :new
+    end
+  end
+
+  private
+
+    def video_params
+      params.require(:video).permit(:title, :description, :category_id)
+    end
 end

--- a/spec/controllers/admin/videos_controller_spec.rb
+++ b/spec/controllers/admin/videos_controller_spec.rb
@@ -30,4 +30,62 @@ describe Admin::VideosController do
       expect(flash[:danger]).not_to be_nil
     end
   end
+
+  describe "POST#create" do
+    it_behaves_like "redirect_to_sign_in" do
+      let(:action) { post :create }
+    end
+
+    it_behaves_like "requires admin" do
+      let(:action) { post :create }
+    end
+
+    context "with valid input" do
+      before do
+        set_current_admin
+      end
+
+      it "redirects to the add video page" do
+        category = Fabricate(:category)
+        post :create, video: { title: "Video Title", description: "Video Description", category_id: category.id }
+        expect(response).to redirect_to new_admin_video_path
+      end
+
+      it "creates a new video" do
+        category = Fabricate(:category)
+        post :create, video: { title: "Video Title", description: "Video Description", category_id: category.id }
+        expect(Video.all.count).to eq(1)
+      end
+
+      it "sets the flash message" do
+        category = Fabricate(:category)
+        post :create, video: { title: "Video Title", description: "Video Description", category_id: category.id }
+        expect(flash[:success]).not_to be_nil
+      end
+    end
+
+    context "with invalid input" do
+      before do
+        set_current_admin
+      end
+
+      it "renders the new template" do
+        category = Fabricate(:category)
+        post :create, video: { description: "Video Description", category_id: category.id }
+        expect(response).to render_template :new
+      end
+
+      it "sets the video" do
+        category = Fabricate(:category)
+        post :create, video: { description: "Video Description", category_id: category.id }
+        expect(:video).to be_present
+      end
+
+      it "sets the flash message" do
+        category = Fabricate(:category)
+        post :create, video: { description: "Video Description", category_id: category.id }
+        expect(flash[:danger]).to be_present
+      end
+    end
+  end
 end

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -6,6 +6,14 @@ shared_examples "redirect_to_sign_in" do
   end
 end
 
+shared_examples "requires admin" do
+  it "redirects to the home path" do
+    session[:user_id] = Fabricate(:user)
+    action
+    expect(response).to redirect_to home_path
+  end
+end
+
 shared_examples "tokenable" do
   it "adds a token attribute to the object" do
     object.generate_token


### PR DESCRIPTION
A properly logged in admin can now add a new video with a valid title, description and category. Have not yet wired up the ability to attach images.
